### PR TITLE
Fix/show currently logged in wallet

### DIFF
--- a/api/functions/graphql/nexus-typegen.ts
+++ b/api/functions/graphql/nexus-typegen.ts
@@ -234,6 +234,7 @@ export interface NexusGenObjects {
     payment_request: string; // String!
   }
   WalletKey: { // root type
+    is_current: boolean; // Boolean!
     key: string; // String!
     name: string; // String!
   }
@@ -469,6 +470,7 @@ export interface NexusGenFieldTypes {
     payment_request: string; // String!
   }
   WalletKey: { // field return type
+    is_current: boolean; // Boolean!
     key: string; // String!
     name: string; // String!
   }
@@ -718,6 +720,7 @@ export interface NexusGenFieldTypeNames {
     payment_request: 'String'
   }
   WalletKey: { // field return type name
+    is_current: 'Boolean'
     key: 'String'
     name: 'String'
   }

--- a/api/functions/graphql/schema.graphql
+++ b/api/functions/graphql/schema.graphql
@@ -314,6 +314,7 @@ type Vote {
 }
 
 type WalletKey {
+  is_current: Boolean!
   key: String!
   name: String!
 }

--- a/api/functions/graphql/types/users.js
+++ b/api/functions/graphql/types/users.js
@@ -55,10 +55,10 @@ const MyProfile = objectType({
         t.string('nostr_pub_key')
 
         t.nonNull.list.nonNull.field('walletsKeys', {
-            type: "WalletKey",
-            resolve: (parent) => {
-                return prisma.user.findUnique({ where: { id: parent.id } }).userKeys();
-
+            type: 'WalletKey',
+            resolve: async (parent, _, context) => {
+                const userKeys = await prisma.user.findUnique({ where: { id: parent.id } }).userKeys();
+                return userKeys.map(k => ({ ...k, is_current: k.key === context.userPubKey }))
             }
         });
     }
@@ -144,6 +144,7 @@ const WalletKey = objectType({
     definition(t) {
         t.nonNull.string('key');
         t.nonNull.string('name');
+        t.nonNull.boolean('is_current')
     }
 })
 

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/LinkedAccountsCard.tsx
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/LinkedAccountsCard.tsx
@@ -51,31 +51,11 @@ export default function LinkedAccountsCard({ value, onChange }: Props) {
                         <WalletKey
                             key={idx}
                             walletKey={item}
-                            canDelete={value.length > 1}
                             onRename={v => updateKeyName(idx, v)}
                             onDelete={() => deleteKey(idx)}
                         />
                     )}
                 </ul>
-                {/* <div className="flex justify-end gap-8">
-                    <Button
-                        color='gray'
-                        className=''
-                        disabled={!keysState.hasNewChanges || updatingKeysStatus.loading}
-                        onClick={cancelChanges}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        color='black'
-                        className=''
-                        disabled={!keysState.hasNewChanges}
-                        isLoading={updatingKeysStatus.loading}
-                        onClick={saveChanges}
-                    >
-                        Save Changes
-                    </Button>
-                </div> */}
             </div>
             {value.length < 3 &&
                 <Button color='none' size='sm' className='mt-16 text-gray-600 hover:bg-gray-50' onClick={connectNewWallet}>

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/WalletKey.tsx
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/WalletKey.tsx
@@ -11,20 +11,18 @@ import { openModal } from "src/redux/features/modals.slice";
 
 interface Props {
     walletKey: WalletKeyType,
-    canDelete: boolean;
     onRename: (newName: string) => void
     onDelete: () => void
 }
 
 
 
-export default function WalletKey({ walletKey, canDelete, onRename, onDelete }: Props) {
+export default function WalletKey({ walletKey, onRename, onDelete }: Props) {
 
     const ref = useRef<HTMLInputElement>(null!);
     const [name, setName] = useState(walletKey.name);
     const [editMode, toggleEditMode] = useToggle(false);
     const dispatch = useAppDispatch();
-
 
     const CONFIRM_DELETE_WALLET = useMemo(() => createAction<{ confirmed?: boolean }>(`CONFIRM_DELETE_WALLET_${walletKey.key.slice(0, 10)}`)({}), [walletKey.key])
 
@@ -80,11 +78,17 @@ export default function WalletKey({ walletKey, canDelete, onRename, onDelete }: 
                         onClick={saveNameChanges}
                     >Save</Button>}
             </div>
-            {canDelete && <IconButton
-                size='sm'
-                className='text-red-500 shrink-0'
-                onClick={() => handleDelete()}
-            ><FiTrash2 /> </IconButton>}
+            <div className="min-w-[60px] flex justify-center">
+                {!walletKey.is_current ?
+                    <IconButton
+                        size='sm'
+                        className='text-red-500 shrink-0 mx-auto'
+                        onClick={() => handleDelete()}
+                    ><FiTrash2 /> </IconButton>
+                    :
+                    <span className="text-body5 text-gray-400">(Current)</span>
+                }
+            </div>
         </li>
     )
 }

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/profilePreferences.graphql
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/profilePreferences.graphql
@@ -4,6 +4,7 @@ query MyProfilePreferences {
     walletsKeys {
       key
       name
+      is_current
     }
     nostr_prv_key
     nostr_pub_key

--- a/src/graphql/index.tsx
+++ b/src/graphql/index.tsx
@@ -467,6 +467,7 @@ export type Vote = {
 
 export type WalletKey = {
   __typename?: 'WalletKey';
+  is_current: Scalars['Boolean'];
   key: Scalars['String'];
   name: Scalars['String'];
 };
@@ -573,7 +574,7 @@ export type PostDetailsQuery = { __typename?: 'Query', getPostById: { __typename
 export type MyProfilePreferencesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MyProfilePreferencesQuery = { __typename?: 'Query', me: { __typename?: 'MyProfile', id: number, nostr_prv_key: string | null, nostr_pub_key: string | null, walletsKeys: Array<{ __typename?: 'WalletKey', key: string, name: string }> } | null };
+export type MyProfilePreferencesQuery = { __typename?: 'Query', me: { __typename?: 'MyProfile', id: number, nostr_prv_key: string | null, nostr_pub_key: string | null, walletsKeys: Array<{ __typename?: 'WalletKey', key: string, name: string, is_current: boolean }> } | null };
 
 export type UpdateUserPreferencesMutationVariables = Exact<{
   walletsKeys: InputMaybe<Array<UserKeyInputType> | UserKeyInputType>;
@@ -1387,6 +1388,7 @@ export const MyProfilePreferencesDocument = gql`
     walletsKeys {
       key
       name
+      is_current
     }
     nostr_prv_key
     nostr_pub_key

--- a/src/mocks/data/users.ts
+++ b/src/mocks/data/users.ts
@@ -22,11 +22,13 @@ export const user: User & MyProfile = {
     walletsKeys: [
         {
             key: "1645h234j2421zxvertw",
-            name: "My Alby wallet key"
+            name: "My Alby wallet key",
+            is_current: true
         },
         {
             key: "6643534534534534543",
-            name: "My Phoenix wallet key"
+            name: "My Phoenix wallet key",
+            is_current: false
         },
     ]
 }


### PR DESCRIPTION
Currently, in the user wallet management tab, the user is able to delete any key as long as at least one is left, but the problem is when he deletes his currently logged in with key, then he will be logged out immediately from his account.

And this might not be a bad thing, but he might have lost access to his other wallet, so now he is locked forever out of his account.

So the proposed solution is to only allow the user to delete accounts that don't include the currently logged in with one.
If he wants to delete this one, he will need to login to his account from one of his other wallets, and delete this key from there.