### PR TITLE
fix: show currently logged in user in linked-wallets card

### DIFF
--- a/api/functions/graphql/nexus-typegen.ts
+++ b/api/functions/graphql/nexus-typegen.ts
@@ -234,6 +234,7 @@ export interface NexusGenObjects {
     payment_request: string; // String!
   }
   WalletKey: { // root type
+    is_current: boolean; // Boolean!
     key: string; // String!
     name: string; // String!
   }
@@ -469,6 +470,7 @@ export interface NexusGenFieldTypes {
     payment_request: string; // String!
   }
   WalletKey: { // field return type
+    is_current: boolean; // Boolean!
     key: string; // String!
     name: string; // String!
   }
@@ -718,6 +720,7 @@ export interface NexusGenFieldTypeNames {
     payment_request: 'String'
   }
   WalletKey: { // field return type name
+    is_current: 'Boolean'
     key: 'String'
     name: 'String'
   }

--- a/api/functions/graphql/schema.graphql
+++ b/api/functions/graphql/schema.graphql
@@ -314,6 +314,7 @@ type Vote {
 }
 
 type WalletKey {
+  is_current: Boolean!
   key: String!
   name: String!
 }

--- a/api/functions/graphql/types/users.js
+++ b/api/functions/graphql/types/users.js
@@ -56,9 +56,9 @@ const MyProfile = objectType({
 
         t.nonNull.list.nonNull.field('walletsKeys', {
             type: "WalletKey",
-            resolve: (parent) => {
-                return prisma.user.findUnique({ where: { id: parent.id } }).userKeys();
-
+            resolve: async (parent, _, context) => {
+                const userKeys = await prisma.user.findUnique({ where: { id: parent.id } }).userKeys();
+                return userKeys.map(k => ({ ...k, is_current: k.key === context.userPubKey }))
             }
         });
     }
@@ -144,6 +144,7 @@ const WalletKey = objectType({
     definition(t) {
         t.nonNull.string('key');
         t.nonNull.string('name');
+        t.nonNull.boolean('is_current')
     }
 })
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "server:preview": "env-cmd -f ./envs/server/preview.env  serverless offline",
     "client:prod-server": "env-cmd -f ./envs/client/prod-server.env react-scripts start",
     "server:prod": "env-cmd -f ./envs/server/prod.env  serverless offline",
-    "client:mocks": "env-cmd -f ./envs/client/.mock-server.env react-scripts start",
+    "client:mocks": "env-cmd -f ./envs/client/mock-server.env react-scripts start",
     "generate-graphql": "graphql-codegen",
     "storybook": "env-cmd -f ./envs/client/.dev.preview-server.env start-storybook -p 6006 -s public",
     "storybook:mocks": "env-cmd -f ./envs/client/.dev.mock-server.env start-storybook -p 6006 -s public",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-loader-spinner": "^6.0.0-0",
     "react-loading-skeleton": "^3.1.0",
     "react-modal": "^3.15.1",
+    "react-popper-tooltip": "^4.4.2",
     "react-query": "^3.35.0",
     "react-redux": "^8.0.0",
     "react-router-dom": "^6.3.0",

--- a/src/features/Auth/pages/LoginPage/LoginPage.tsx
+++ b/src/features/Auth/pages/LoginPage/LoginPage.tsx
@@ -158,14 +158,14 @@ export default function LoginPage() {
             <h2 className='text-h5 font-bold text-center'>Login with lightning ⚡</h2>
             <a href={`lightning:${lnurl}`} >
                 <QRCodeSVG
-                    width={240}
-                    height={240}
+                    width={280}
+                    height={280}
                     value={lnurl}
                     bgColor='transparent'
                     imageSettings={{
                         src: '/assets/images/nut_3d.png',
-                        width: 32,
-                        height: 32,
+                        width: 16,
+                        height: 16,
                         excavate: true,
 
                     }}

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/LinkedAccountsCard.tsx
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/LinkedAccountsCard.tsx
@@ -51,31 +51,11 @@ export default function LinkedAccountsCard({ value, onChange }: Props) {
                         <WalletKey
                             key={idx}
                             walletKey={item}
-                            canDelete={value.length > 1}
                             onRename={v => updateKeyName(idx, v)}
                             onDelete={() => deleteKey(idx)}
                         />
                     )}
                 </ul>
-                {/* <div className="flex justify-end gap-8">
-                    <Button
-                        color='gray'
-                        className=''
-                        disabled={!keysState.hasNewChanges || updatingKeysStatus.loading}
-                        onClick={cancelChanges}
-                    >
-                        Cancel
-                    </Button>
-                    <Button
-                        color='black'
-                        className=''
-                        disabled={!keysState.hasNewChanges}
-                        isLoading={updatingKeysStatus.loading}
-                        onClick={saveChanges}
-                    >
-                        Save Changes
-                    </Button>
-                </div> */}
             </div>
             {value.length < 3 &&
                 <Button color='none' size='sm' className='mt-16 text-gray-600 hover:bg-gray-50' onClick={connectNewWallet}>

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/LinkedAccountsCard.tsx
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/LinkedAccountsCard.tsx
@@ -38,6 +38,7 @@ export default function LinkedAccountsCard({ value, onChange }: Props) {
         onChange([...value.slice(0, idx), ...value.slice(idx + 1)])
     }
 
+    const hasMultiWallets = value.length > 1;
 
     return (
         <Card>
@@ -50,6 +51,7 @@ export default function LinkedAccountsCard({ value, onChange }: Props) {
                     {value.map((item, idx) =>
                         <WalletKey
                             key={idx}
+                            hasMultiWallets={hasMultiWallets}
                             walletKey={item}
                             onRename={v => updateKeyName(idx, v)}
                             onDelete={() => deleteKey(idx)}

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/WalletKey.tsx
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/WalletKey.tsx
@@ -8,6 +8,8 @@ import { useReduxEffect } from 'src/utils/hooks/useReduxEffect';
 import { WalletKeyType } from './LinkedAccountsCard'
 import { useAppDispatch } from "src/utils/hooks";
 import { openModal } from "src/redux/features/modals.slice";
+import 'react-popper-tooltip/dist/styles.css';
+import { usePopperTooltip } from 'react-popper-tooltip';
 
 interface Props {
     walletKey: WalletKeyType,
@@ -24,6 +26,15 @@ export default function WalletKey({ walletKey, onRename, onDelete }: Props) {
     const [editMode, toggleEditMode] = useToggle(false);
     const dispatch = useAppDispatch();
 
+
+
+    const {
+        getArrowProps,
+        getTooltipProps,
+        setTooltipRef,
+        setTriggerRef,
+        visible,
+    } = usePopperTooltip();
 
     const CONFIRM_DELETE_WALLET = useMemo(() => createAction<{ confirmed?: boolean }>(`CONFIRM_DELETE_WALLET_${walletKey.key.slice(0, 10)}`)({}), [walletKey.key])
 
@@ -86,9 +97,21 @@ export default function WalletKey({ walletKey, onRename, onDelete }: Props) {
                         className='text-red-500 shrink-0 mx-auto'
                         onClick={() => handleDelete()}
                     ><FiTrash2 /> </IconButton>
-                    :
-                    <span className="text-body5 text-gray-400">(Current)</span>
+                    : <>
+                        <span ref={setTriggerRef} className="text-body5 text-gray-400">(Current)</span>
+                        {visible && (
+                            <div
+                                ref={setTooltipRef}
+                                {...getTooltipProps({ className: 'tooltip-container' })}
+                            >
+                                <div {...getArrowProps({ className: 'tooltip-arrow' })} />
+                                Tooltip
+                            </div>
+                        )}
+                    </>
+
                 }
+
             </div>
         </li>
     )

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/WalletKey.tsx
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/WalletKey.tsx
@@ -1,7 +1,7 @@
 import { useToggle } from '@react-hookz/web';
 import { createAction } from '@reduxjs/toolkit';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { FiTrash2 } from 'react-icons/fi';
+import { FiTrash2, FiLock } from 'react-icons/fi';
 import Button from 'src/Components/Button/Button';
 import IconButton from 'src/Components/IconButton/IconButton';
 import { useReduxEffect } from 'src/utils/hooks/useReduxEffect';
@@ -13,13 +13,14 @@ import { usePopperTooltip } from 'react-popper-tooltip';
 
 interface Props {
     walletKey: WalletKeyType,
+    hasMultiWallets?: boolean;
     onRename: (newName: string) => void
     onDelete: () => void
 }
 
 
 
-export default function WalletKey({ walletKey, onRename, onDelete }: Props) {
+export default function WalletKey({ walletKey, hasMultiWallets, onRename, onDelete }: Props) {
 
     const ref = useRef<HTMLInputElement>(null!);
     const [name, setName] = useState(walletKey.name);
@@ -90,7 +91,7 @@ export default function WalletKey({ walletKey, onRename, onDelete }: Props) {
                         onClick={saveNameChanges}
                     >Save</Button>}
             </div>
-            <div className="min-w-[60px] flex justify-center">
+            {hasMultiWallets && <div className="min-w-[60px] flex justify-center">
                 {!walletKey.is_current ?
                     <IconButton
                         size='sm'
@@ -98,21 +99,23 @@ export default function WalletKey({ walletKey, onRename, onDelete }: Props) {
                         onClick={() => handleDelete()}
                     ><FiTrash2 /> </IconButton>
                     : <>
-                        <span ref={setTriggerRef} className="text-body5 text-gray-400">(Current)</span>
+                        <span ref={setTriggerRef} >
+                            <FiLock className="text-body4 text-gray-400" />
+                        </span>
                         {visible && (
                             <div
                                 ref={setTooltipRef}
-                                {...getTooltipProps({ className: 'tooltip-container' })}
+                                {...getTooltipProps({ className: 'tooltip-container !bg-gray-900 !text-white text-body5 !rounded-12 !p-12' })}
                             >
                                 <div {...getArrowProps({ className: 'tooltip-arrow' })} />
-                                Tooltip
+                                You're now logged-in with this wallet. <br /> To remove it, login to your account with a different wallet.
                             </div>
                         )}
                     </>
 
                 }
 
-            </div>
+            </div>}
         </li>
     )
 }

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/WalletKey.tsx
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/LinkedAccountsCard/WalletKey.tsx
@@ -11,14 +11,13 @@ import { openModal } from "src/redux/features/modals.slice";
 
 interface Props {
     walletKey: WalletKeyType,
-    canDelete: boolean;
     onRename: (newName: string) => void
     onDelete: () => void
 }
 
 
 
-export default function WalletKey({ walletKey, canDelete, onRename, onDelete }: Props) {
+export default function WalletKey({ walletKey, onRename, onDelete }: Props) {
 
     const ref = useRef<HTMLInputElement>(null!);
     const [name, setName] = useState(walletKey.name);
@@ -80,11 +79,17 @@ export default function WalletKey({ walletKey, canDelete, onRename, onDelete }: 
                         onClick={saveNameChanges}
                     >Save</Button>}
             </div>
-            {canDelete && <IconButton
-                size='sm'
-                className='text-red-500 shrink-0'
-                onClick={() => handleDelete()}
-            ><FiTrash2 /> </IconButton>}
+            <div className="min-w-[60px] flex justify-center">
+                {!walletKey.is_current ?
+                    <IconButton
+                        size='sm'
+                        className='text-red-500 shrink-0 mx-auto'
+                        onClick={() => handleDelete()}
+                    ><FiTrash2 /> </IconButton>
+                    :
+                    <span className="text-body5 text-gray-400">(Current)</span>
+                }
+            </div>
         </li>
     )
 }

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/PreferencesTab.Skeleton.tsx
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/PreferencesTab.Skeleton.tsx
@@ -16,12 +16,15 @@ export default function PreferencesTabSkeleton() {
                     <div className='mt-24 flex flex-col gap-16'>
                         <ul className="mt-8 relative flex flex-col gap-8">
                             {Array(3).fill(0).map((_, idx) =>
-                                <li key={idx} className="flex flex-wrap gap-16 justify-between items-center text-body4 border-b py-12 px-16 border border-gray-200 rounded-16 focus-within:ring-1 ring-primary-200">
-                                    <div className='p-0 border-0 focus:border-0 focus:outline-none grow
+                                <div key={idx} className='flex gap-16'>
+                                    <li className="grow flex flex-wrap gap-16 justify-between items-center text-body4 border-b py-12 px-16 border border-gray-200 rounded-16 focus-within:ring-1 ring-primary-200">
+                                        <div className='p-0 border-0 focus:border-0 focus:outline-none grow
                                                 focus:ring-0 placeholder:!text-gray-400' >
-                                        <Skeleton width='20ch'></Skeleton>
-                                    </div>
-                                </li>
+                                            <Skeleton width='20ch'></Skeleton>
+                                        </div>
+                                    </li>
+                                    <div className="min-w-[60px]"></div>
+                                </div>
                             )}
                         </ul>
 

--- a/src/features/Profiles/pages/EditProfilePage/PreferencesTab/profilePreferences.graphql
+++ b/src/features/Profiles/pages/EditProfilePage/PreferencesTab/profilePreferences.graphql
@@ -4,6 +4,7 @@ query MyProfilePreferences {
     walletsKeys {
       key
       name
+      is_current
     }
     nostr_prv_key
     nostr_pub_key

--- a/src/graphql/index.tsx
+++ b/src/graphql/index.tsx
@@ -467,6 +467,7 @@ export type Vote = {
 
 export type WalletKey = {
   __typename?: 'WalletKey';
+  is_current: Scalars['Boolean'];
   key: Scalars['String'];
   name: Scalars['String'];
 };
@@ -573,7 +574,7 @@ export type PostDetailsQuery = { __typename?: 'Query', getPostById: { __typename
 export type MyProfilePreferencesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MyProfilePreferencesQuery = { __typename?: 'Query', me: { __typename?: 'MyProfile', id: number, nostr_prv_key: string | null, nostr_pub_key: string | null, walletsKeys: Array<{ __typename?: 'WalletKey', key: string, name: string }> } | null };
+export type MyProfilePreferencesQuery = { __typename?: 'Query', me: { __typename?: 'MyProfile', id: number, nostr_prv_key: string | null, nostr_pub_key: string | null, walletsKeys: Array<{ __typename?: 'WalletKey', key: string, name: string, is_current: boolean }> } | null };
 
 export type UpdateUserPreferencesMutationVariables = Exact<{
   walletsKeys: InputMaybe<Array<UserKeyInputType> | UserKeyInputType>;
@@ -1387,6 +1388,7 @@ export const MyProfilePreferencesDocument = gql`
     walletsKeys {
       key
       name
+      is_current
     }
     nostr_prv_key
     nostr_pub_key

--- a/src/mocks/data/users.ts
+++ b/src/mocks/data/users.ts
@@ -22,11 +22,13 @@ export const user: User & MyProfile = {
     walletsKeys: [
         {
             key: "1645h234j2421zxvertw",
-            name: "My Alby wallet key"
+            name: "My Alby wallet key",
+            is_current: true
         },
         {
             key: "6643534534534534543",
-            name: "My Phoenix wallet key"
+            name: "My Phoenix wallet key",
+            is_current: false
         },
     ]
 }

--- a/src/styles/vendors.scss
+++ b/src/styles/vendors.scss
@@ -39,3 +39,7 @@
   transition-timing-function: ease-in;
   transition-duration: 400ms;
 }
+
+.tooltip-arrow::after {
+  border-color: var(--arrowColor, #101828) transparent !important;
+}


### PR DESCRIPTION
Currently, in the user wallet management tab, the user is able to delete any key as long as at least one is left, but the problem is when he deletes his currently logged in with key, then he will be logged out immediately from his account.

And this might not be a bad thing, but he might have lost access to his other wallet, so now he is locked forever out of his account.

So the proposed solution is to only allow the user to delete accounts that don't include the currently logged in with one.
If he wants to delete this one, he will need to login to his account from one of his other wallets, and delete this key from there.